### PR TITLE
Change header background to light blue tint

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,7 @@
   --color-bg-primary: #ffffff;
   --color-bg-secondary: #f8f9fa;
   --color-bg-sidebar: #f8fafc;
-  --color-bg-header: #ffffff;
+  --color-bg-header: #f0f4ff;
   --color-bg-card: #ffffff;
   --color-bg-input: #ffffff;
   --color-bg-hover: #f1f5f9;


### PR DESCRIPTION
## Summary
- Update header background from white (#ffffff) to light blue (#f0f4ff)
- Gives the header a subtle blue tint to match the new accent color scheme

## Test plan
- [ ] Visual regression tests detect header color change across all pages