### PR TITLE
Switch header to dark theme with light text

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -5,7 +5,7 @@
   --color-bg-primary: #ffffff;
   --color-bg-secondary: #f8f9fa;
   --color-bg-sidebar: #f8fafc;
-  --color-bg-header: #f0f4ff;
+  --color-bg-header: #1e293b;
   --color-bg-card: #ffffff;
   --color-bg-input: #ffffff;
   --color-bg-hover: #f1f5f9;
@@ -14,7 +14,7 @@
   --color-text-secondary: #64748b;
   --color-text-sidebar: #475569;
   --color-text-sidebar-active: #0f172a;
-  --color-text-header: #0f172a;
+  --color-text-header: #f8fafc;
 
   --color-border: #e2e8f0;
   --color-border-input: #cbd5e1;


### PR DESCRIPTION
## Summary
- Change header background from light (#f0f4ff) to dark slate (#1e293b)
- Change header text from dark (#0f172a) to light (#f8fafc) for contrast

## Test plan
- [ ] Visual regression tests detect the dark header across all pages