### PR TITLE
Increase border radius and add green tint to cards

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -6,7 +6,7 @@
   --color-bg-secondary: #f8f9fa;
   --color-bg-sidebar: #f8fafc;
   --color-bg-header: #1e293b;
-  --color-bg-card: #ffffff;
+  --color-bg-card: #f0fdf4;
   --color-bg-input: #ffffff;
   --color-bg-hover: #f1f5f9;
 
@@ -39,9 +39,9 @@
   --spacing-2xl: calc(var(--spacing-unit) * 12);
 
   /* Border radius */
-  --radius-sm: 4px;
-  --radius-md: 8px;
-  --radius-lg: 12px;
+  --radius-sm: 8px;
+  --radius-md: 16px;
+  --radius-lg: 24px;
   --radius-full: 9999px;
 
   /* Shadows */


### PR DESCRIPTION
## Summary
- Double all border radius values (sm: 4→8, md: 8→16, lg: 12→24) for a more rounded look
- Change card background from white (#ffffff) to light green (#f0fdf4)

## Test plan
- [ ] Visual regression tests detect rounder corners and green card tint