### PR TITLE
Change accent color from blue to orange

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -19,8 +19,8 @@
   --color-border: #e2e8f0;
   --color-border-input: #cbd5e1;
 
-  --color-accent: #3b82f6;
-  --color-accent-hover: #2563eb;
+  --color-accent: #f97316;
+  --color-accent-hover: #ea580c;
 
   --color-success: #22c55e;
   --color-success-bg: #dcfce7;


### PR DESCRIPTION
## Summary
- Update accent color from blue (#3b82f6) to orange (#f97316)
- Update accent hover from #2563eb to #ea580c
- Affects sidebar active state, buttons, and other accent elements

## Test plan
- [ ] Visual regression tests detect orange accent across all pages